### PR TITLE
Remove pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-future==0.15.2
-PyYAML==3.11
+future
+PyYAML

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     keywords=['glue', 'glu', 'dry', 'config', 'dry-config', 'dry-configurable'],
     zip_safe=False,
     install_requires=[
-        'future==0.15.2',
-        'PyYAML==3.11'
+        'future',
+        'PyYAML'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Hi,

Some people I'm helping are having an issue with dependencies being too old.  This PR relaxes them and installs for me.  Could this be taken and possibly a new release made?  A course is starting soon and it's very hard for students to get the code if there's not a release.

Let me know if there's more I can do to help.

cc @tolou65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chongkong/glu/2)
<!-- Reviewable:end -->
